### PR TITLE
Fix typo in fairroot.sh module file

### DIFF
--- a/fairroot.sh
+++ b/fairroot.sh
@@ -57,7 +57,7 @@ set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
 module load BASE/1.0                                                                            \\
-            FairSoft/$FAIRSOFT_VERSION-$FAIRSOFT_REVISION}                                      \\
+            FairSoft/$FAIRSOFT_VERSION-$FAIRSOFT_REVISION
 # Our environment
 setenv FAIRROOT_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv VMCWORKDIR \$::env(FAIRROOT_ROOT)/share/fairbase/examples


### PR DESCRIPTION
There seems to be a trivial typo in the module file for FairRoot, which causes trouble when trying to load it (paraphrasing: modules `#`, `Our` and `environment` can not be found by `alienv`).

This commit removes the unmatched closing brace and removes the escaped line-ending mistake.

Sorry if this is a known issue or this is not the right place to bring this up, I work for a downstream experiment, so don't know your process.

---

Checklist:

* [x] Rebased against `master` branch
* [x] Followed [guidelines for commit messages](https://github.com/FairRootGroup/alfadist#guidelines-for-commit-messages)
* [x] Followed [guidelines for contributing recipes](https://github.com/FairRootGroup/alfadist#guidelines-for-contributing-recipes)
* [x] Followed [guidelines for handling external sources](https://github.com/FairRootGroup/alfadist#guidelines-for-handling-external-sources)
